### PR TITLE
fix the uint8 indexing warning with PyTorch 1.2+

### DIFF
--- a/torch_complex/functional.py
+++ b/torch_complex/functional.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import functools
 from typing import Sequence
 from typing import Union
@@ -6,6 +7,8 @@ import torch
 from torch.nn import functional as F
 
 from torch_complex.tensor import ComplexTensor
+
+is_torch_1_2_plus = LooseVersion(torch.__version__) >= LooseVersion('1.2')
 
 
 def _fcomplex(func, nthargs=0):
@@ -123,7 +126,8 @@ def signal_frame(signal: torch.Tensor,
 
 
 def trace(a: ComplexTensor) -> ComplexTensor:
-    E = torch.eye(a.real.size(-1), dtype=torch.uint8).expand(*a.size())
+    datatype = torch.bool if is_torch_1_2_plus else torch.uint8
+    E = torch.eye(a.real.size(-1), dtype=datatype).expand(*a.size())
     return a[E].view(*a.size()[:-1]).sum(-1)
 
 


### PR DESCRIPTION
Hi, I find that `trace()` in `pytorch_complex` will cause the following warning with PyTorch 1.2+:
```
../aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
```
This is fixed in this pull request.