### PR TITLE
Increase torch compatibility

### DIFF
--- a/torch_complex/functional.py
+++ b/torch_complex/functional.py
@@ -46,7 +46,7 @@ def einsum(equation, *operands):
     >>> numpy.testing.assert_allclose(test.numpy(), valid)
 
     """
-    if len(operands) == 1 and isinstance(operands, (tuple, list)):
+    if len(operands) == 1:
         operands = operands[0]
 
     x = operands[0]

--- a/torch_complex/tensor.py
+++ b/torch_complex/tensor.py
@@ -535,8 +535,16 @@ class ComplexTensor:
     def numpy(self) -> numpy.ndarray:
         return self.real.numpy() + 1j * self.imag.numpy()
 
+    def __array__(self):
+        # https://numpy.org/devdocs/user/basics.dispatch.html
+        return self.real.__array__() + 1j * self.imag.__array__()
+
     def permute(self, *dims) -> "ComplexTensor":
         return ComplexTensor(self.real.permute(*dims), self.imag.permute(*dims))
+
+    @property
+    def T(self):
+        return ComplexTensor(self.real.T, self.imag.T)
 
     def pow(self, exponent) -> "ComplexTensor":
         return self ** exponent
@@ -575,6 +583,13 @@ class ComplexTensor:
 
     def size(self, *args, **kwargs) -> torch.Size:
         return self.real.size(*args, **kwargs)
+
+    def ndimension(self):
+        return self.real.ndimension()
+
+    @property
+    def ndim(self):
+        return self.real.ndim
 
     def sqrt(self) -> "ComplexTensor":
         return self ** 0.5

--- a/torch_complex/tensor.py
+++ b/torch_complex/tensor.py
@@ -598,8 +598,20 @@ class ComplexTensor:
         return ComplexTensor(self.real.squeeze(dim), self.imag.squeeze(dim))
 
     def sum(self, *args, **kwargs) -> "ComplexTensor":
+        """
+        sum(self, dim, keepdim, *, dtype=None)
+        sum(self, axis, keepdims, *, dtype=None)  # numpy style
+
+        Args:
+            dim or axis:
+            keepdim or keepdims:
+            **kwargs:
+
+        Returns:
+
+        """
         return ComplexTensor(
-            self.real.sum(*args, **kwargs), self.imag.sum(*args, **kwargs),
+            self.real.sum(*args, **kwargs), self.imag.sum(*args, **kwargs)
         )
 
     def take(self, indices) -> "ComplexTensor":

--- a/torch_complex/tensor.py
+++ b/torch_complex/tensor.py
@@ -205,12 +205,15 @@ class ComplexTensor:
         return len(self.real)
 
     def __repr__(self) -> str:
+        import textwrap
+
         return (
-            "ComplexTensor(\nReal:\n"
-            + repr(self.real)
-            + "\nImag:\n"
-            + repr(self.imag)
-            + "\n)"
+            "ComplexTensor("
+            + "\n    real="
+            + textwrap.indent(repr(self.real), " " * len("    real=")).lstrip(" ")
+            + ",\n    imag="
+            + textwrap.indent(repr(self.imag), " " * len("    imag=")).lstrip(" ")
+            + ",\n)"
         )
 
     def __abs__(self) -> torch.Tensor:


### PR DESCRIPTION
 - I added some properties and methods to ComplexTensor and forwarded them to the rel and imag part.
 - torch supports `dim` and `axis`. To be a drop in replacement, I changed the signature of some functions to have `*args` and `**kwargs` (Sadly torch has multiple signatures for most functions).
 - I also changed the repr of ComplexTensor. I think with indents it is better to read.