### PR TITLE
Fix einsum for single argument and minor changes

### DIFF
--- a/torch_complex/functional.py
+++ b/torch_complex/functional.py
@@ -44,9 +44,11 @@ def einsum(equation, *operands):
     ...               [ComplexTensor(x), ComplexTensor(y), ComplexTensor(z)])
     >>> valid = numpy.einsum('aij,ajk,akl->ail', x, y, z)
     >>> numpy.testing.assert_allclose(test.numpy(), valid)
+    >>> _ = einsum('aij->ai', ComplexTensor(x))
+    >>> _ = einsum('aij->ai', [ComplexTensor(x)])
 
     """
-    if len(operands) == 1:
+    if len(operands) == 1 and isinstance(operands[0], (tuple, list)):
         operands = operands[0]
 
     x = operands[0]

--- a/torch_complex/functional.py
+++ b/torch_complex/functional.py
@@ -122,7 +122,7 @@ def stack(seq: Sequence[Union[ComplexTensor, torch.Tensor]], *args, **kwargs):
 
 
 pad = _fcomplex(F.pad)
-
+squeeze = _fcomplex(torch.squeeze)
 
 @_fcomplex
 def reverse(tensor: torch.Tensor, dim=0) -> torch.Tensor:

--- a/torch_complex/tensor.py
+++ b/torch_complex/tensor.py
@@ -316,7 +316,17 @@ class ComplexTensor:
 
     @property
     def dtype(self) -> torch.dtype:
+        # Warning: Try to never use this dtype property.
+        #          It will break your code, when you change to the native
+        #          complex type.
+        #          Use instead directly `complex_tensor.real.dtype`.
         return self.real.dtype
+
+    def is_floating_point(self):
+        return False
+    
+    def is_complex(self):
+        return True
 
     def eq(self, other) -> torch.Tensor:
         if isinstance(other, (ComplexTensor, complex)):

--- a/torch_complex/tensor.py
+++ b/torch_complex/tensor.py
@@ -14,6 +14,9 @@ class ComplexTensor:
                     real = real.real
                 else:
                     imag = numpy.zeros_like(real)
+            elif isinstance(real, ComplexTensor):
+                imag = real.imag
+                real = real.real
             else:
                 imag = torch.zeros_like(real)
 


### PR DESCRIPTION
 - Fix einsum for single argument and add doctest
 - Allow `ComplexTensor(ComplexTensor(...))`
 - Add `squeeze`
 - Add `is_floating_point` and `is_complex` methods to ComplexTensor
 - Add comment warning to dtype:
    - I am not sure, if you want to consider this: Some people may use this package now and want to change to the native implementation later. Some methods and properties are incompatible to the native implementation. One example is the dtype property, here it is the float type, while it is the complex type in torch master.