### PR TITLE
Repalce distutils.version.LooseVersion with packaging.version.parse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='torch_complex',
       author_email='naoyuki.kamo829@gmail.com',
       url='https://github.com/kamo-naoyuki/torch_complex',
       packages=find_packages(include=['torch_complex']),
-      install_requires=['numpy'],
+      install_requires=['packaging', 'numpy'],
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'pytest-cov'],
       classifiers=[

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,9 +1,8 @@
-from distutils.version import LooseVersion
-
 import numpy
 import pytest
 
 import torch
+from packaging.version import parse as V
 import torch_complex.functional as F
 from torch_complex.tensor import ComplexTensor
 
@@ -47,7 +46,7 @@ def test_trace():
 
 
 @pytest.mark.skipif(
-    LooseVersion(torch.__version__) < LooseVersion("1.1"), reason="requires torch>=1.1"
+    V(torch.__version__) < V("1.1"), reason="requires torch>=1.1"
 )
 def test_solve():
     t = ComplexTensor(_get_complex_array(1, 10, 10))

--- a/torch_complex/functional.py
+++ b/torch_complex/functional.py
@@ -1,9 +1,9 @@
-from distutils.version import LooseVersion
 import functools
 from typing import Sequence
 from typing import Union
 
 import torch
+from packaging.version import parse as V
 from torch.nn import functional as F
 
 from torch_complex.tensor import ComplexTensor
@@ -175,12 +175,12 @@ def signal_frame(
 
 
 def trace(a: ComplexTensor) -> ComplexTensor:
-    if LooseVersion(torch.__version__) >= LooseVersion("1.3"):
+    if V(torch.__version__) >= V("1.3"):
         datatype = torch.bool
     else:
         datatype = torch.uint8
     E = torch.eye(a.shape[-1], dtype=datatype).expand(*a.size())
-    if LooseVersion(torch.__version__) >= LooseVersion("1.1"):
+    if V(torch.__version__) >= V("1.1"):
         E = E.type(torch.bool)
     return a[E].view(*a.size()[:-1]).sum(-1)
 
@@ -232,7 +232,7 @@ def solve(b: ComplexTensor, a: ComplexTensor, return_LU=False) -> ComplexTensor:
     """Solve ax = b"""
     a = complex_matrix2real_matrix(a)
     b = complex_vector2real_vector(b)
-    if LooseVersion(torch.__version__) >= LooseVersion("1.8"):
+    if V(torch.__version__) >= V("1.8"):
         if return_LU:
             LU, pivots = torch.lu(a)
             x = torch.lu_solve(b, LU, pivots)


### PR DESCRIPTION
This PR replaces `distutils.version.LooseVersion` (deprecated in Python 3.10) with `packaging.version.parse` to avoid errors in Python 3.12+.